### PR TITLE
Fix crashing with new steamodded versions

### DIFF
--- a/InterfacePreview.lua
+++ b/InterfacePreview.lua
@@ -7,14 +7,9 @@ local orig_hud = create_UIBox_HUD
 function create_UIBox_HUD()
    local contents = orig_hud()
    
-
-   local score_node_wrap = {n=G.UIT.R, config={id = "fn_pre_score_wrap", align = "cm", padding = 0.1}, nodes={}}
-   table.insert(score_node_wrap.nodes, FN.PRE.get_score_node())
-   local calculate_score_button_wrap = {n=G.UIT.R, config={id = "fn_calculate_score_button_wrap", align = "cm", padding = 0.1}, nodes={}}
-   table.insert(calculate_score_button_wrap.nodes, FN.PRE.get_calculate_score_button())
-      
-   table.insert(contents.nodes[1].nodes[1].nodes[4].nodes[1].nodes, score_node_wrap)
-   table.insert(contents.nodes[1].nodes[1].nodes[4].nodes[1].nodes, calculate_score_button_wrap)
+   local hand_text_area = FN.PRE.find_hand_text_area(contents)
+   if not hand_text_area then return contents end
+   table.insert(hand_text_area.nodes[1].nodes, FN.PRE.get_preview_container())
 
    --[[local dollars_node_wrap = {n=G.UIT.C, config={id = "fn_pre_dollars_wrap", align = "cm"}, nodes={}}
    if G.SETTINGS.FN.preview_dollars then table.insert(dollars_node_wrap.nodes, FN.PRE.get_dollars_node()) end
@@ -27,8 +22,20 @@ function G.FUNCS.calculate_score_button()
    FN.PRE.start_new_coroutine()
 end
 
-function FN.PRE.get_calculate_score_button()
+function FN.PRE.get_preview_container()
+   return {n=G.UIT.R, config={id = "fn_preview_container", align = "cm"}, nodes={
+      {n=G.UIT.C, config={align = "cm"}, nodes={
+         {n=G.UIT.R, config={id = "fn_pre_score_wrap", align = "cm", padding = 0.1}, nodes={
+            FN.PRE.get_score_node()
+         }},
+         {n=G.UIT.R, config={id = "fn_calculate_score_button_wrap", align = "cm", padding = 0.1}, nodes={
+            FN.PRE.get_calculate_score_button()
+         }}
+      }}
+   }}
+end
 
+function FN.PRE.get_calculate_score_button()
    return {n=G.UIT.C, config={id = "calculate_score_button", button = "calculate_score_button", align = "cm", minh = 0.42, padding = 0.05, r = 0.02, colour = G.C.RED, hover = true, shadow = true}, nodes={
       {n=G.UIT.R, config={align = "cm"}, nodes={
          {n=G.UIT.T, config={text = "  Calculate Score  ", colour = G.C.UI.TEXT_LIGHT, shadow = true, scale = 0.36}}
@@ -46,6 +53,19 @@ function FN.PRE.get_score_node()
               {n=G.UIT.O, config={id = "fn_pre_l", func = "fn_pre_score_UI_set", object = DynaText({string = {{ref_table = FN.PRE.text.score, ref_value = "l"}}, colours = {G.C.UI.TEXT_LIGHT}, shadow = true, float = true, scale = text_scale})}},
               {n=G.UIT.O, config={id = "fn_pre_r", func = "fn_pre_score_UI_set", object = DynaText({string = {{ref_table = FN.PRE.text.score, ref_value = "r"}}, colours = {G.C.UI.TEXT_LIGHT}, shadow = true, float = true, scale = text_scale})}},
    }}
+end
+
+function FN.PRE.find_hand_text_area(node)
+   if node.config and node.config.id == "hand_text_area" then
+      return node
+   end
+   if node.nodes then
+      for _, child in ipairs(node.nodes) do
+         local found = FN.PRE.find_hand_text_area(child, id)
+         if found then return found end
+      end
+   end
+   return nil
 end
 
 --[[function FN.PRE.get_dollars_node()

--- a/UtilsSimulate.lua
+++ b/UtilsSimulate.lua
@@ -76,16 +76,28 @@ function FN.SIM.adjust_field_with_range(adj_func, field, mod_func, exact_value, 
    FN.SIM.running.max[field]   = mod_func(adj_func(FN.SIM.running.max[field],   max_value))
 end
 
+
+-- local copies of the functions in functions/misc_functions.lua to avoid ui updates from steamodded patches to these functions.
+function FN.SIM.mod_chips(_chips)
+   if G.GAME.modifiers.chips_dollar_cap then
+      _chips = math.min(_chips, math.max(G.GAME.dollars, 0))
+   end
+   return _chips
+end
+function FN.SIM.mod_mult(_mult)
+   return _mult
+end
+
 function FN.SIM.add_chips(exact, min, max)
-   FN.SIM.adjust_field_with_range(function(x, y) return x + y end, "chips", mod_chips, exact, min, max)
+   FN.SIM.adjust_field_with_range(function(x, y) return x + y end, "chips", FN.SIM.mod_chips, exact, min, max)
 end
 
 function FN.SIM.add_mult(exact, min, max)
-   FN.SIM.adjust_field_with_range(function(x, y) return x + y end, "mult", mod_mult, exact, min, max)
+   FN.SIM.adjust_field_with_range(function(x, y) return x + y end, "mult", FN.SIM.mod_mult, exact, min, max)
 end
 
 function FN.SIM.x_mult(exact, min, max)
-   FN.SIM.adjust_field_with_range(function(x, y) return x * y end, "mult", mod_mult, exact, min, max)
+   FN.SIM.adjust_field_with_range(function(x, y) return x * y end, "mult", FN.SIM.mod_mult, exact, min, max)
 end
 
 function FN.SIM.add_dollars(exact, min, max)


### PR DESCRIPTION
Finally figured out the steamodded crash. Fantoms was adding the preview nodes at the same level as the chipsxmult containers, so they became involved in SMODS score calculation stuff where it caused a crash.

Once the crash was gone I saw the chips display was being updated with the calculated values because steamodded patches some vanilla getter functions with something to update the ui. Don't ask me why they do that, but I just wrote local versions.