### PR TITLE
Fantoms Preview Plus

### DIFF
--- a/CorePreview.lua
+++ b/CorePreview.lua
@@ -13,10 +13,6 @@ end
 -- ie. whenever the player modifies card selection or card order.
 
 function FN.PRE.simulate()
-   -- Guard against simulating in redundant places:
-   if FN.PRE.five_second_coroutine and coroutine.status(FN.PRE.five_second_coroutine) == "suspended" then
-      coroutine.resume(FN.PRE.five_second_coroutine)
-   end
    if not (G.STATE == G.STATES.SELECTING_HAND or
            G.STATE == G.STATES.DRAW_TO_HAND or
            G.STATE == G.STATES.PLAY_TAROT)
@@ -62,7 +58,9 @@ end
 local orig_hl = CardArea.parse_highlighted
 function CardArea:parse_highlighted()
    orig_hl(self)
-   if not FN.PRE.lock_updates and FN.PRE.show_preview then
+   if FN.PRE.auto_calculate then
+      FN.PRE.show_preview = G.hand ~= nil and #G.hand.highlighted > 0
+   else
       FN.PRE.show_preview = false
    end
    FN.PRE.add_update_event("immediate")
@@ -126,7 +124,7 @@ function FN.PRE.update_on_card_order_change(cardarea)
       elseif cardarea.config.type == 'hand' then
          FN.PRE.hand_order = prev_order
       end
-      if FN.PRE.show_preview and not FN.PRE.lock_updates then
+      if not FN.PRE.auto_calculate then
          FN.PRE.show_preview = false
       end
       FN.PRE.add_update_event("immediate")
@@ -167,33 +165,44 @@ end
 
 -- Add animation to preview text:
 function G.FUNCS.fn_pre_score_UI_set(e)
+   if not (G.STATE == G.STATES.SELECTING_HAND or
+           G.STATE == G.STATES.DRAW_TO_HAND or
+           G.STATE == G.STATES.PLAY_TAROT or
+           G.STATE == G.STATES.HAND_PLAYED) then
+      if FN.PRE.text.score[e.config.id:sub(-1)] ~= " " then
+         FN.PRE.text.score[e.config.id:sub(-1)] = " "
+         e.config.object:update_text()
+         G.FUNCS.text_super_juice(e, 0)
+         e.config.object.colours = {G.C.UI.TEXT_LIGHT}
+      end
+      return
+   end
    local new_preview_text = ""
    local should_juice = false
-   if FN.PRE.lock_updates then 
-      if e.config.id == "fn_pre_l" then
-         new_preview_text = " CALCULATING "
-         should_juice = true
-      end
-   else  
-      if FN.PRE.data then
-         if FN.PRE.show_preview and (FN.PRE.data.score.min ~= FN.PRE.data.score.max) then
-            -- Format as 'X - Y' :
-            if e.config.id == "fn_pre_l" then
-               new_preview_text = FN.PRE.format_number(FN.PRE.data.score.min) .. " - "
-               if FN.PRE.is_enough_to_win(FN.PRE.data.score.min) then should_juice = true end
-            elseif e.config.id == "fn_pre_r" then
-               new_preview_text = FN.PRE.format_number(FN.PRE.data.score.max)
-               if FN.PRE.is_enough_to_win(FN.PRE.data.score.max) then should_juice = true end
-            end
-         else
-            -- Format as single number:
-            if e.config.id == "fn_pre_l" then
-               if true then
-                  -- Spaces around number necessary to distinguish Min/Max text from Exact text,
-                  -- which is itself necessary to force a HUD update when switching between Min/Max and Exact.
-                  if FN.PRE.show_preview then 
-                     new_preview_text = " " .. FN.PRE.format_number(FN.PRE.data.score.min) .. " "
-                     if FN.PRE.is_enough_to_win(FN.PRE.data.score.min) then should_juice = true end
+   local should_warn = false
+   if FN.PRE.data then
+      if FN.PRE.show_preview and (FN.PRE.data.score.min ~= FN.PRE.data.score.max) then
+         -- Format as 'X - Y' :
+         if e.config.id == "fn_pre_l" then
+            new_preview_text = FN.PRE.format_number(FN.PRE.data.score.min) .. " - "
+            if FN.PRE.is_enough_to_win(FN.PRE.data.score.min) then should_juice = true
+            else should_warn = true end
+         elseif e.config.id == "fn_pre_r" then
+            new_preview_text = FN.PRE.format_number(FN.PRE.data.score.max)
+            if FN.PRE.is_enough_to_win(FN.PRE.data.score.max) then should_juice = true end
+         end
+      else
+         -- Format as single number:
+         if e.config.id == "fn_pre_l" then
+            if true then
+               -- Spaces around number necessary to distinguish Min/Max text from Exact text,
+               -- which is itself necessary to force a HUD update when switching between Min/Max and Exact.
+               if FN.PRE.show_preview then
+                  new_preview_text = " " .. FN.PRE.format_number(FN.PRE.data.score.min) .. " "
+                  if FN.PRE.is_enough_to_win(FN.PRE.data.score.min) then should_juice = true
+                  elseif FN.PRE.is_last_hand() and not FN.PRE.is_enough_to_win(FN.PRE.data.score.max) then
+                     should_warn = true
+                  end
                   else
                      if FN.PRE.is_enough_to_win(FN.PRE.data.score.min) then 
                         should_juice = true
@@ -222,15 +231,16 @@ function G.FUNCS.fn_pre_score_UI_set(e)
             new_preview_text = ""
          end
       end
-   end
 
    if (not FN.PRE.text.score[e.config.id:sub(-1)]) or new_preview_text ~= FN.PRE.text.score[e.config.id:sub(-1)] then
       FN.PRE.text.score[e.config.id:sub(-1)] = new_preview_text
       e.config.object:update_text()
       -- Wobble:
       if not G.TAROT_INTERRUPT_PULSE then
-         if should_juice
-         then
+         if should_warn then
+            G.FUNCS.text_super_juice(e, 0)
+            e.config.object.colours = {G.C.HAND_LEVELS[6]}
+         elseif should_juice then
             G.FUNCS.text_super_juice(e, 5)
             e.config.object.colours = {G.C.MONEY}
          else

--- a/EngineSimulate.lua
+++ b/EngineSimulate.lua
@@ -236,8 +236,8 @@ if not FN.SIM.run then
          local function flint(data)
             local half_chips = math.floor(data.chips/2 + 0.5)
             local half_mult = math.floor(data.mult/2 + 0.5)
-            data.chips = mod_chips(math.max(half_chips, 0))
-            data.mult  = mod_mult(math.max(half_mult, 1))
+            data.chips = FN.SIM.mod_chips(math.max(half_chips, 0))
+            data.mult  = FN.SIM.mod_mult(math.max(half_mult, 1))
          end
 
          flint(FN.SIM.running.min)
@@ -253,8 +253,8 @@ if not FN.SIM.run then
          local function plasma(data)
             local sum = data.chips + data.mult
             local half_sum = math.floor(sum/2)
-            data.chips = mod_chips(half_sum)
-            data.mult = mod_mult(half_sum)
+            data.chips = FN.SIM.mod_chips(half_sum)
+            data.mult = FN.SIM.mod_mult(half_sum)
          end
 
          plasma(FN.SIM.running.min)

--- a/InitPreview.lua
+++ b/InitPreview.lua
@@ -16,37 +16,9 @@ FN.PRE = {
    joker_order = {},
    hand_order = {},
    show_preview = false,
-   lock_updates = false,
+   auto_calculate = true,
    on_startup = true,
-   five_second_coroutine = nil
 }
-
-function FN.PRE.start_new_coroutine()
-   if FN.PRE.five_second_coroutine and coroutine.status(FN.PRE.five_second_coroutine) ~= "dead" then
-      FN.PRE.five_second_coroutine = nil  -- Reset the coroutine
-   end
-
-   -- Create and start a new coroutine
-   FN.PRE.five_second_coroutine = coroutine.create(function()
-      -- Show UI updates
-      FN.PRE.lock_updates = true
-      FN.PRE.show_preview = true
-      FN.PRE.add_update_event("immediate")  -- Force UI refresh
-
-      local start_time = os.time()
-      while os.time() - start_time < 5 do
-         FN.PRE.simulate()  -- Force a simulation run
-         FN.PRE.add_update_event("immediate")  -- Ensure UI updates
-         coroutine.yield()  -- Allow game to continue running
-      end
-      -- Delay for 5 seconds
-      FN.PRE.lock_updates = false
-      FN.PRE.show_preview = true
-      FN.PRE.add_update_event("immediate")  -- Refresh UI again
-   end)
-
-   coroutine.resume(FN.PRE.five_second_coroutine)  -- Start it immediately
-end
 
 
 

--- a/InterfacePreview.lua
+++ b/InterfacePreview.lua
@@ -19,7 +19,17 @@ function create_UIBox_HUD()
 end
 
 function G.FUNCS.calculate_score_button()
-   FN.PRE.start_new_coroutine()
+   FN.PRE.auto_calculate = not FN.PRE.auto_calculate
+if FN.PRE.auto_calculate then
+      FN.PRE.show_preview = G.hand ~= nil and #G.hand.highlighted > 0
+   else
+      FN.PRE.show_preview = false
+   end
+   FN.PRE.add_update_event("immediate")
+end
+
+function G.FUNCS.calculate_score_button_UI_set(e)
+   e.config.colour = FN.PRE.auto_calculate and G.C.RED or G.C.GREY
 end
 
 function FN.PRE.get_preview_container()
@@ -36,9 +46,9 @@ function FN.PRE.get_preview_container()
 end
 
 function FN.PRE.get_calculate_score_button()
-   return {n=G.UIT.C, config={id = "calculate_score_button", button = "calculate_score_button", align = "cm", minh = 0.42, padding = 0.05, r = 0.02, colour = G.C.RED, hover = true, shadow = true}, nodes={
+   return {n=G.UIT.C, config={id = "calculate_score_button", button = "calculate_score_button", func = "calculate_score_button_UI_set", align = "cm", minh = 0.55, padding = 0.12, r = 0.02, colour = G.C.RED, hover = true, shadow = true}, nodes={
       {n=G.UIT.R, config={align = "cm"}, nodes={
-         {n=G.UIT.T, config={text = "  Calculate Score  ", colour = G.C.UI.TEXT_LIGHT, shadow = true, scale = 0.36}}
+         {n=G.UIT.T, config={text = "  Autocalculate Score  ", colour = G.C.UI.TEXT_LIGHT, shadow = true, scale = 0.4}}
       }}
    }}
 end

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+Removed the 5-second calculation delay File: CorePreview.lua, InitPreview.lua
+The original mod wrapped FN.SIM.run() in a coroutine with an artificial 5-second wait. Since the simulation is fully deterministic and needs only one call, the coroutine and all related state (lock_updates, five_second_coroutine) were removed entirely. Score now calculates instantly.
+
+Auto-calculate mode (button becomes a toggle) Files: InitPreview.lua, InterfacePreview.lua, CorePreview.lua
+Added auto_calculate = true to FN.PRE state (defaults on at startup) The "Calculate Score" button now toggles auto-calculate on/off instead of triggering a one-shot calculation When on: score updates live whenever cards are selected/deselected When off: score display clears
+Button color reflects state: red = on, grey = off (via calculate_score_button_UI_set per-frame func)
+3. Button text and size improvements File: InterfacePreview.lua
+
+Button text changed to " Autocalculate Score "
+Button made slightly larger: minh=0.55, padding=0.12, text scale=0.4
+4. Fixed Plasma Deck + The Hook causing a 5–20 second hang File: EngineSimulate.lua
+
+Root cause: simulate_deck_effects() (Plasma Deck) and simulate_blind_effects() (The Flint) were calling the global mod_chips/mod_mult functions, which are patched by Steamodded to trigger UI/scoring events. With The Hook blind generating up to 29 card-discard combos × 3 runs (min/exact/max), this caused ~87 unintended side-effect calls per preview.
+
+Fix: replaced all calls with FN.SIM.mod_chips() and FN.SIM.mod_mult() — the side-effect-free simulation versions.
+
+E-notation threshold matches vanilla Balatro File: UtilsPreview.lua
+The mod was switching to e-notation at 1e7. Changed to use G.E_SWITCH_POINT or 1e11, which matches vanilla Balatro's threshold (~100 billion).
+
+Warning color when score won't beat the blind File: CorePreview.lua
+Added salmon/pink-red coloring (G.C.HAND_LEVELS[6], #f87d75) in two cases:
+
+Range display (X - Y): the min (left) number turns salmon if it won't beat the blind Single number display: turns salmon if it's the last hand and even the max estimate won't beat the blind The existing gold color (G.C.MONEY) for winning scores is preserved; salmon only appears as a warning.
+
+Score display hidden outside hand-playing states File: CorePreview.lua
+Added an early-return guard in fn_pre_score_UI_set that clears the score text (sets it to a single space to prevent UI compression) when the game is not in one of: SELECTING_HAND, DRAW_TO_HAND, PLAY_TAROT, or HAND_PLAYED. This prevents the score from showing stale numbers on the cash-out screen and other non-game screens.

--- a/UtilsPreview.lua
+++ b/UtilsPreview.lua
@@ -2,6 +2,10 @@
 --
 -- Utilities for checking states and formatting display.
 
+function FN.PRE.is_last_hand()
+   return G.GAME and G.GAME.current_round and G.GAME.current_round.hands_left == 1
+end
+
 function FN.PRE.is_enough_to_win(chips)
    if G.GAME.blind and
       (G.STATE == G.STATES.SELECTING_HAND or
@@ -15,7 +19,7 @@ end
 function FN.PRE.format_number(num)
    if not num or type(num) ~= 'number' then return num or '' end
    -- Start using e-notation earlier to reduce number length, if showing min and max for preview:
-   if true and num >= 1e7 then
+   if true and num >= (G.E_SWITCH_POINT or 1e11) then
       local x = string.format("%.4g",num)
       local fac = math.floor(math.log(tonumber(x), 10))
       return string.format("%.2f",x/(10^fac))..'e'..fac


### PR DESCRIPTION
1. Removed the 5-second calculation delay File: CorePreview.lua, InitPreview.lua

The original mod wrapped FN.SIM.run() in a coroutine with an artificial 5-second wait. Since the simulation is fully deterministic and needs only one call, the coroutine and all related state (lock_updates, five_second_coroutine) were removed entirely. Score now calculates instantly.

2. Auto-calculate mode (button becomes a toggle) Files: InitPreview.lua, InterfacePreview.lua, CorePreview.lua

Added auto_calculate = true to FN.PRE state (defaults on at startup) The "Calculate Score" button now toggles auto-calculate on/off instead of triggering a one-shot calculation When on: score updates live whenever cards are selected/deselected When off: score display clears
Button color reflects state: red = on, grey = off (via calculate_score_button_UI_set per-frame func)
3. Button text and size improvements File: InterfacePreview.lua

Button text changed to " Autocalculate Score "
Button made slightly larger: minh=0.55, padding=0.12, text scale=0.4
4. Fixed Plasma Deck + The Hook causing a 5–20 second hang File: EngineSimulate.lua

Root cause: simulate_deck_effects() (Plasma Deck) and simulate_blind_effects() (The Flint) were calling the global mod_chips/mod_mult functions, which are patched by Steamodded to trigger UI/scoring events. With The Hook blind generating up to 29 card-discard combos × 3 runs (min/exact/max), this caused ~87 unintended side-effect calls per preview.

Fix: replaced all calls with FN.SIM.mod_chips() and FN.SIM.mod_mult() — the side-effect-free simulation versions.

5. E-notation threshold matches vanilla Balatro File: UtilsPreview.lua

The mod was switching to e-notation at 1e7. Changed to use G.E_SWITCH_POINT or 1e11, which matches vanilla Balatro's threshold (~100 billion).

6. Warning color when score won't beat the blind File: CorePreview.lua

Added salmon/pink-red coloring (G.C.HAND_LEVELS[6], #f87d75) in two cases:

Range display (X - Y): the min (left) number turns salmon if it won't beat the blind Single number display: turns salmon if it's the last hand and even the max estimate won't beat the blind The existing gold color (G.C.MONEY) for winning scores is preserved; salmon only appears as a warning.

7. Score display hidden outside hand-playing states File: CorePreview.lua

Added an early-return guard in fn_pre_score_UI_set that clears the score text (sets it to a single space to prevent UI compression) when the game is not in one of: SELECTING_HAND, DRAW_TO_HAND, PLAY_TAROT, or HAND_PLAYED. This prevents the score from showing stale numbers on the cash-out screen and other non-game screens.